### PR TITLE
use items() for Python 3 compatibility

### DIFF
--- a/templates/default/02_exim4-custom_options
+++ b/templates/default/02_exim4-custom_options
@@ -1,5 +1,5 @@
 {% if exim4_custom_options is defined and exim4_custom_options %}
-{% for key, value in exim4_custom_options.iteritems() %}
+{% for key, value in exim4_custom_options.items() %}
 {{ key }} = {{ value }}
 {% endfor %}
 {% endif %}

--- a/templates/keyvalue.j2
+++ b/templates/keyvalue.j2
@@ -1,3 +1,3 @@
-{% for key, value in item.data.iteritems() %}
+{% for key, value in item.data.items() %}
 {{ key }}: {{ value }}
 {% endfor %}


### PR DESCRIPTION
iteritems() was removed in Python 3
(see https://github.com/UnderGreen/ansible-prometheus-node-exporter/issues/3,
https://www.python.org/dev/peps/pep-0469/).
As Ansible depends heavily on Python, compatibility matters,
especially because Python 2 is close to its end of life
(see https://pythonclock.org/).
items() works in both Python 2 and Python 3,
and since we are dealing with short lists and powerful computing nodes
when using this particular Ansible template,
replacing iteritems() with items() should be a no-brainer.