### PR TITLE
fix #2: ensure group ssl-cert exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,16 @@
     - exim4-reconfigure
     - exim4-reconfigure-logrotate
 
+- name: Ensure SSL cert group exists
+  when: authldap is not defined or not authldap
+  action: group
+  args:
+    name: ssl-cert
+    state: present
+  tags:
+    - exim4
+    - exim4-user
+
 - name: Add Exim user into SSL group
   when: authldap is not defined or not authldap
   action: user


### PR DESCRIPTION
Newer Debian systems come without an ssl-cert group
by default. I am not sure when exactly that change was applied,
but other users have had trouble with it, too,
so I decided to propose my fix for upstream.

Unlike @slgevens who authored pull request #3
to address this problem among others, I believe that
we should not try to toggle group adding itself,
but rather add the group always as an option to store
mail server SSL certificates securely on the remote host.
Also, we keep backwards compatibility by making sure
that the group is present when adding the exim user,
as the operation will have no effect on older Debian systems
and long-time users, but will fix the problem for newcomers
with no high impact on their system setup.

In addition, I think that this change is not incompatible
with #3. If the need arises we can flag the new task,
avoiding group creation and group adding altogether.